### PR TITLE
fix(monitoring): change probe URL from GH homepage to .git URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ async function run(params) {
     });
   }
   return wrap(action, {
-    github: 'https://github.com/',
+    github: 'https://github.com/adobe/helix-resolve-git-ref.git/info/refs?service=git-upload-pack',
   })(params);
 }
 


### PR DESCRIPTION
Instead of probing the availability of the GitHub home page, this change uses the GitHub `.git` repository URL of the helix-resolve-ref repository itself, which is a better indicator of availability

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
